### PR TITLE
herokuのwebhookのエラーを解決

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -13,11 +13,6 @@ end
 post '/callback' do
   body = request.body.read
   signature = request.env['HTTP_X_LINE_SIGNATURE']
-  puts("----A----")
-  puts(body)
-  puts("----B----")
-  print(signature)
-  puts("----C----")
   unless client.validate_signature(body, signature)
     error 400 do 'Bad Request' end
   end


### PR DESCRIPTION
## issue番号
close #4 

## 実装内容

- herokuのwebhookのエラーを解決
  - putsで区切り、bodyとsignatureの中身を検証
  ログをherokuコマンドで確認したところ、ログが取れていることを確認した。
  - チャネルアクセストークンの再発行など環境変数の見直し
  再発行したものの状況は変わらなかった。
   - herokuに環境変数を登録
   `heroku config:set LINE_CHANNEL_SECRET=自分のチャンネルシークレット`
   `heroku config:set LINE_CHANNEL_TOKEN=自分のアクセストークン`
    上記のコマンドを打つことでwebhookのエラーが解消（LINE Developersのwebhookの検証がOKになり、LINE Bot上でオウム返しができるようになった）
  
## 参考資料
- herokuのwebhookのエラーを解決
  - [line-bot-sdk-ruby](https://github.com/line/line-bot-sdk-ruby)
  - [Ruby + SinatraでLINE Botを作ろう](https://www.mizucoffee.com/archives/1076)
  -   [Webhookとは？](https://qiita.com/soarflat/items/ed970f6dc59b2ab761694)
  - [Pythonのline-bot-sdkで作ったBotが、Webhook URLのVerifyに失敗する件を調査した](https://qiita.com/hiro0236/items/c1d41be73817d0ad5cec)
  - [HTTPステータスコードチェッカー](https://singoro.net/http-status-code/)
  - [ランダムで2つのキーワードを返してくれるシンプルなLINE botを作ってみよう！](techpit)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x]  影響し得る範囲のローカル環境での動作確認