### PR TITLE
通知の切り替え

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -35,7 +35,12 @@ post '/callback' do
       case event.type
       when Line::Bot::Event::MessageType::Text
         # 文字列が入力された場合
-
+        case event.message['text']
+        when /.*(1|１|スタート).*/
+          p 'テスト1'
+        when /.*(2|２|ストップ).*/
+          p 'テスト2'
+        end
       when Line::Bot::Event::MessageType::Location
         # 位置情報が入力された場合
         

--- a/app.rb
+++ b/app.rb
@@ -40,8 +40,10 @@ post '/callback' do
           $db.notification_enable_user(user_id)
           info = $db.get_notifications(user_id)
           reply_text = %{#{info['pref']} #{info['area']} の天気をお知らせします！}
+          reply_text << "\n\nお知らせを停止するときは「2」または「ストップ」と入力してください。\n\n地域を設定するときは 位置情報 を送信してください。"
         when /.*(2|２|ストップ).*/
-          
+          $db.notification_disnable_user(user_id)
+          reply_text = "お知らせの停止を受け付けました。\n\nお知らせを開始するときは「1」または「スタート」と入力してください。\n\n使い方を見たい場合は何か話しかけてください。"
         end
       when Line::Bot::Event::MessageType::Location
         # 位置情報が入力された場合

--- a/app.rb
+++ b/app.rb
@@ -37,9 +37,11 @@ post '/callback' do
         # 文字列が入力された場合
         case event.message['text']
         when /.*(1|１|スタート).*/
-          p 'テスト1'
+          $db.notification_enable_user(user_id)
+          info = $db.get_notifications(user_id)
+          reply_text = %{#{info['pref']} #{info['area']} の天気をお知らせします！}
         when /.*(2|２|ストップ).*/
-          p 'テスト2'
+          
         end
       when Line::Bot::Event::MessageType::Location
         # 位置情報が入力された場合

--- a/notification.sql
+++ b/notification.sql
@@ -1,0 +1,6 @@
+create table notifications (
+  user_id varchar(64) primary key, 
+  hour int,
+  minute int,
+  notification_disabled boolean default false
+)

--- a/notification.sql
+++ b/notification.sql
@@ -2,5 +2,6 @@ create table notifications (
   user_id varchar(64) primary key, 
   hour int,
   minute int,
+  area_id int,
   notification_disabled boolean default false
 )

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -64,7 +64,7 @@ class WeatherDbConnector
 
   def notification_disnable_user(user_id)
     p 'disnable_user'
-    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict(user_id) do update set user_id = values('#{user_id}'), notification_disabled = values(notification_disabled)")
+    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notification_disabled = excluded.notification_disabled;")
   end
 
   def set_location(user_id, latitude, longitude)

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -66,7 +66,7 @@ class WeatherDbConnector
 
   def notification_enable_user(user_id)
     p 'enable_user'
-    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, false) on confict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
+    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, false) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
   end
 
   def notification_disnable_user(user_id)

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -59,12 +59,12 @@ class WeatherDbConnector
 
   def notification_enable_user(user_id)
     p 'enable_user'
-    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, false) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
+    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, false) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
   end
 
   def notification_disnable_user(user_id)
     p 'disnable_user'
-    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, true) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
+    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
   end
 
   def set_location(user_id, latitude, longitude)

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -4,6 +4,7 @@ require 'dotenv/load'
 class WeatherDbConnector
   DEFAULT_WEATHER_HOUR = 7
   DEFAULT_WEATHER_MINUTE = 0
+  DEFAULT_AREA_ID = 1
 
   # 環境変数を使って接続する
   ActiveRecord::Base.establish_connection(
@@ -60,7 +61,7 @@ class WeatherDbConnector
     p 'set_location'
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result['id']},#{result['pref']},#{result['area']},#{result['latitude']},#{result['longitude']}"
-      @conn.execute("insert into notifications (user_id, hour,minute) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}) on conflict(user_id) do update set user_id = values(user_id)")
+      @conn.execute("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},#{DEFAULT_AREA_ID},) on conflict(user_id) do update set area_id = values('#{area_id}')")
     return result['pref'], result['area']
   end
 

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -26,10 +26,15 @@ class WeatherDbConnector
   end
 
   def create_weathers
-    p 'create_weathers_table'
+    p 'create_table'
     File.open('create_weathers.sql', 'r:utf-8') do |f|
       createsql = f.read
       @conn.execute(createsql)
+    end
+
+    File.open("notification.sql", "r:utf-8") do |f|
+      notificationsql = f.read
+      @conn.execute(notificationsql)
     end
   end
 

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -71,7 +71,7 @@ class WeatherDbConnector
     p "set_location"
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result["id"]},#{result["pref"]},#{result["area"]},#{result["latitude"]},#{result["longitude"]}"
-    @conn.execute("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},#{result["id"]},) on conflict(user_id) do update set area_id = values('#{area_id}')")
+    @conn.execute("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},'#{result["id"]}') on conflict(user_id) do update set area_id = ('#{result["id"]}')")
     return result["pref"], result["area"]
   end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -78,7 +78,7 @@ class WeatherDbConnector
 
   def get_all_notifications
    p 'get_all_notifications'
-   results = @conn.execute('select * from notifications inner join weathers on (notifications.area_id = weathers.id);')
+   results = @conn.execute('select * from notifications inner join weathers on notifications.area_id = weathers.id;')
    results.each do |row|
     puts "----------------------------"
     p row
@@ -88,7 +88,7 @@ class WeatherDbConnector
 
   def get_notifications(user_id)
     p 'get_notifications(user_id)'
-    results = @conn.execute("select * from notifications inner join weathers on (notifications.area_id = weathers.id where notifications.user_id = '#{user_id}');")
+    results = @conn.execute("select * from notifications inner join weathers on notifications.area_id = weathers.id where notifications.user_id = '#{user_id}';")
     results.each do |row|
       puts "----------------------------"
       p row

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -60,6 +60,7 @@ class WeatherDbConnector
     p 'set_location'
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result['id']},#{result['pref']},#{result['area']},#{result['latitude']},#{result['longitude']}"
+      @conn.execute("insert into notifications (user_id, hour,minute) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}) on confict(user_id) do update set user_id = values(user_id)")
     return result['pref'], result['area']
   end
 

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -59,12 +59,12 @@ class WeatherDbConnector
 
   def notification_enable_user(user_id)
     p 'enable_user'
-    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, false) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
+    @conn.execute("insert into notifications (user_id, hour, minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, false) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notification_disabled = excluded.notification_disabled;")
   end
 
   def notification_disnable_user(user_id)
     p 'disnable_user'
-    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
+    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict(user_id) do update set user_id = values('#{user_id}'), notification_disabled = values(notification_disabled)")
   end
 
   def set_location(user_id, latitude, longitude)

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -76,6 +76,12 @@ class WeatherDbConnector
   end
 
   def get_all_notifications
-
+   p 'get_all_notifications'
+   results = @conn.execute('select * from notifications inner join weathers on (notifications.area_id = weathers.id);')
+   results.each do |row|
+    puts "----------------------------"
+    p row
+   end
+   return results
   end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -60,7 +60,7 @@ class WeatherDbConnector
     p 'set_location'
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result['id']},#{result['pref']},#{result['area']},#{result['latitude']},#{result['longitude']}"
-      @conn.execute("insert into notifications (user_id, hour,minute) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}) on confict(user_id) do update set user_id = values(user_id)")
+      @conn.execute("insert into notifications (user_id, hour,minute) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}) on conflict(user_id) do update set user_id = values(user_id)")
     return result['pref'], result['area']
   end
 

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -64,12 +64,12 @@ class WeatherDbConnector
     return result['pref'], result['area']
   end
 
-  def notification_enable_user
+  def notification_enable_user(user_id)
     p 'enable_user'
     @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, false) on confict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
   end
 
-  def notification_disnable_user
+  def notification_disnable_user(user_id)
     p 'disnable_user'
     @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, true) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
   end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -94,4 +94,9 @@ class WeatherDbConnector
     end
     return results.first
   end
+
+  def fix_notifications
+    p 'fix_notifications'
+    @conn.execute("update notifications set hour = 7, minute = 0 where hour is null")
+  end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -30,13 +30,14 @@ class WeatherDbConnector
   end
 
   def create_weathers
-    p 'create_table'
+    p 'create_weathers_table'
     File.open('create_weathers.sql', 'r:utf-8') do |f|
       createsql = f.read
       @conn.execute(createsql)
     end
 
-    File.open("notification.sql", "r:utf-8") do |f|
+    p 'create_notifications_table'
+    File.open('notification.sql', 'r:utf-8') do |f|
       notificationsql = f.read
       @conn.execute(notificationsql)
     end
@@ -53,8 +54,8 @@ class WeatherDbConnector
 
   def drop_weathers
     p 'drop_weathers_table'
-    weathers = Weather.table_name
-    @conn.drop_table(weathers)
+    @conn.execute("drop table if exists weathers")
+    @conn.execute("drop table if exists notifications")
   end
 
   def notification_enable_user(user_id)

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -2,6 +2,9 @@ require 'active_record'
 require 'dotenv/load'
 
 class WeatherDbConnector
+  DEFAULT_WEATHER_HOUR = 7
+  DEFAULT_WEATHER_MINUTE = 0
+
   # 環境変数を使って接続する
   ActiveRecord::Base.establish_connection(
     adapter: ENV['myadapter'],
@@ -58,5 +61,15 @@ class WeatherDbConnector
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result['id']},#{result['pref']},#{result['area']},#{result['latitude']},#{result['longitude']}"
     return result['pref'], result['area']
+  end
+
+  def notification_enable_user
+    p 'enable_user'
+    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, false")
+  end
+
+  def notification_disnable_user
+    p 'disnable_user'
+    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, true")
   end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -57,14 +57,6 @@ class WeatherDbConnector
     @conn.drop_table(weathers)
   end
 
-  def set_location(user_id, latitude, longitude)
-    p 'set_location'
-    result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
-    puts "#{result['id']},#{result['pref']},#{result['area']},#{result['latitude']},#{result['longitude']}"
-      @conn.execute("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},#{DEFAULT_AREA_ID},) on conflict(user_id) do update set area_id = values('#{area_id}')")
-    return result['pref'], result['area']
-  end
-
   def notification_enable_user(user_id)
     p 'enable_user'
     @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, false) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
@@ -73,5 +65,13 @@ class WeatherDbConnector
   def notification_disnable_user(user_id)
     p 'disnable_user'
     @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, true) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
+  end
+
+  def set_location(user_id, latitude, longitude)
+    p "set_location"
+    result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
+    puts "#{result["id"]},#{result["pref"]},#{result["area"]},#{result["latitude"]},#{result["longitude"]}"
+    @conn.execute("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},#{result["id"]},) on conflict(user_id) do update set area_id = values('#{area_id}')")
+    return result["pref"], result["area"]
   end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -84,4 +84,14 @@ class WeatherDbConnector
    end
    return results
   end
+
+  def get_all_notifications(user_id)
+    p 'get_all_notifications(user_id)'
+    results = @conn.execute("select * from notifications inner join weathers on (notifications.area_id = weathers.id where notifications.user_id = '#{user_id}');")
+    results.each do |row|
+      puts "----------------------------"
+      p row
+    end
+    return results.first
+  end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -85,8 +85,8 @@ class WeatherDbConnector
    return results
   end
 
-  def get_all_notifications(user_id)
-    p 'get_all_notifications(user_id)'
+  def get_notifications(user_id)
+    p 'get_notifications(user_id)'
     results = @conn.execute("select * from notifications inner join weathers on (notifications.area_id = weathers.id where notifications.user_id = '#{user_id}');")
     results.each do |row|
       puts "----------------------------"

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -68,10 +68,14 @@ class WeatherDbConnector
   end
 
   def set_location(user_id, latitude, longitude)
-    p "set_location"
+    p 'set_location'
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result["id"]},#{result["pref"]},#{result["area"]},#{result["latitude"]},#{result["longitude"]}"
     @conn.execute("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},'#{result["id"]}') on conflict(user_id) do update set area_id = ('#{result["id"]}')")
     return result["pref"], result["area"]
+  end
+
+  def get_all_notifications
+
   end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -65,11 +65,11 @@ class WeatherDbConnector
 
   def notification_enable_user
     p 'enable_user'
-    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, false")
+    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, false) on confict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
   end
 
   def notification_disnable_user
     p 'disnable_user'
-    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, true")
+    @conn.execute("insert into notifications (user_id, hour,minute, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, true) on conflict(user_id) do update set user_id = values(user_id), notification_disabled = values(notification_disabled)")
   end
 end


### PR DESCRIPTION
## issue番号

close #30 

## 実装内容
- 通知の切り替え
    - notificationsテーブルを作成（`notificationDisabled(boolean型)`を項目に入れて通知を切り替え）
    - notificationsテーブルとweathersテーブルを内部結合して`user_id`を取得、該当のユーザーへ通知が届くようにする
    - スタートで通知を開始、ストップで通知を停止できるように設定

## 参考資料
- [毎朝 天気を通知する LINE Bot を作ってみました。](https://takagusu.hateblo.jp/entry/2017/01/24/200453)
- [Active Record の基礎](https://railsguides.jp/active_record_basics.html)
- [LINE Developersドキュメント-リクエストボディ](https://developers.line.biz/ja/reference/messaging-api/#send-reply-message)
- [ブーリアン型](https://ja.wikipedia.org/wiki/%E3%83%96%E3%83%BC%E3%83%AA%E3%82%A2%E3%83%B3%E5%9E%8B)
- [postgreSQLでSELECT/UPSERT](https://qiita.com/sa9ra4ma/items/fca7105b152914793bd6)
- [【SQL Server/IF EXISTS】テーブルが存在している場合、テーブルを削除する](https://sqlserver.work/2020/08/23/%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E3%81%8C%E5%AD%98%E5%9C%A8%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E5%A0%B4%E5%90%88%E3%80%81%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB%E3%82%92%E5%89%8A%E9%99%A4%E3%81%99/)
- [SQL素人でも分かるテーブル結合(inner joinとouter join)](https://zenn.dev/naoki_mochizuki/articles/60603b2cdc273cd51c59)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット

- 地域を設定していない状態で`スタート`と送信するとデフォルトの地域が設定される(北海道北見地域)
https://user-images.githubusercontent.com/70443334/131767625-c289ff4c-03a6-4588-aac5-2add32967efa.mp4

- ` 1`または`スタート`、`2`または`ストップ`でメッセージの文言が変わる（通知の開始と停止を切り替える）
https://user-images.githubusercontent.com/70443334/131767695-2b488ddb-4190-4ca4-a98a-301c5152cf5d.mp4



