### PR TITLE
選択した地域の天気情報を取得

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,7 @@ Bundler.require
 require 'sinatra/reloader' if development?
 require './weather_db_connector'
 require './weather_info_connector'
+require 'date'
 
 $db = WeatherDbConnector.new
 
@@ -34,8 +35,19 @@ post '/callback' do
       
       case event.type
       when Line::Bot::Event::MessageType::Text
-        # 文字列が入力された場合
+        case event.message['text']
+        when /.*(3|３|天気).*/
+          weather_info_conn = WeatherInfoConnector.new
+          begin
+            # weather = WeatherInfoConnector.new('愛知県', '西部', 'http://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', 0)
+          rescue => e
+            reply_text = weather_info_conn.get_weatherinfo('愛知県', '西部', 'http://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', set_day = 1) #名古屋駅
+            p e
+          end
+        end
 
+        d = DateTime.now
+        p "現在の時刻は#{d.hour}時#{d.min}分です"
       when Line::Bot::Event::MessageType::Location
         # 位置情報が入力された場合
         
@@ -47,7 +59,6 @@ post '/callback' do
         reply_text = %{地域を#{pref} #{area}にセットしました！\n\n「3」または「天気」と入力すると、現在設定されている地域の天気をお知らせします。}
         
       end
-
     end
     message = {
           type: "text",

--- a/app.rb
+++ b/app.rb
@@ -45,13 +45,13 @@ post '/callback' do
         when /.*(2|２|ストップ).*/
           $db.notification_disnable_user(user_id)
           reply_text = "お知らせの停止を受け付けました。\n\nお知らせを開始するときは「1」または「スタート」と入力してください。\n\n使い方を見たい場合は何か話しかけてください。"
-        end
         when /.*(3|３|天気).*/
           weather_info_conn = WeatherInfoConnector.new
           begin
-            # weather = WeatherInfoConnector.new('愛知県', '西部', 'http://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', 0)
+            info = $db.get_notifications(user_id)
+            reply_text = weather_info_conn.get_weatherinfo(info['pref'], info['area'], info['url'].sub(/http/, 'https'), info['xpath'], set_day = 0)
           rescue => e
-            reply_text = weather_info_conn.get_weatherinfo('愛知県', '西部', 'http://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', set_day = 1) #名古屋駅
+            reply_text = weather_info_conn.get_weatherinfo('愛知県', '西部', 'https://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', set_day = 1) #名古屋駅
             p e
           end
         end
@@ -64,7 +64,6 @@ post '/callback' do
         puts "緯度と経度を取得しました！"
         pref, area = $db.set_location(user_id, latitude, longitude)
         reply_text = %{地域を#{pref} #{area}にセットしました！\n\n「3」または「天気」と入力すると、現在設定されている地域の天気をお知らせします。}
-        
       end
     end
     message = {

--- a/app.rb
+++ b/app.rb
@@ -45,17 +45,35 @@ post '/callback' do
         when /.*(2|２|ストップ).*/
           $db.notification_disnable_user(user_id)
           reply_text = "お知らせの停止を受け付けました。\n\nお知らせを開始するときは「1」または「スタート」と入力してください。\n\n使い方を見たい場合は何か話しかけてください。"
-        when /.*(3|３|天気).*/
+        when /.*(3|３|天気|てんき).*/
           weather_info_conn = WeatherInfoConnector.new
           begin
             info = $db.get_notifications(user_id)
             reply_text = weather_info_conn.get_weatherinfo(info['pref'], info['area'], info['url'].sub(/http/, 'https'), info['xpath'], set_day = 0)
           rescue => e
-            reply_text = weather_info_conn.get_weatherinfo('愛知県', '西部', 'https://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', set_day = 1) #名古屋駅
+            reply_text = weather_info_conn.get_weatherinfo('愛知県', '西部', 'https://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', set_day = 0) #名古屋駅
             p e
           end
+        when /.*(明日|あした).*/
+          weather_info_conn = WeatherInfoConnector.new
+          begin
+            info = $db.get_notifications(user_id)
+            reply_text = weather_info_conn.get_weatherinfo(info['pref'], info['area'], info['url'].sub(/http/, 'https'), info['xpath'], set_day = 1)
+          rescue => e
+            reply_text = weather_info_conn.get_weatherinfo('愛知県', '西部', 'https://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', set_day = 1) 
+            p e
+          end
+        when /.*(明後日|あさって).*/
+          weather_info_conn = WeatherInfoConnector.new
+          begin
+            info = $db.get_notifications(user_id)
+            reply_text = weather_info_conn.get_weatherinfo(info['pref'], info['area'], info['url'].sub(/http/, 'https'), info['xpath'], set_day = 2)
+          rescue => e
+            reply_text = weather_info_conn.get_weatherinfo('愛知県', '西部', 'https://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', set_day = 2) 
+            p e
+          end  
         end
-      when Line::Bot::Event::MessageType::Location
+      when Line::Bot::Evqent::MessageType::Location
         # 位置情報が入力された場合
         
         # 緯度と経度を取得

--- a/app.rb
+++ b/app.rb
@@ -73,7 +73,7 @@ post '/callback' do
             p e
           end  
         end
-      when Line::Bot::Evqent::MessageType::Location
+      when Line::Bot::Event::MessageType::Location
         # 位置情報が入力された場合
         
         # 緯度と経度を取得

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -51,7 +51,7 @@ class WeatherDbConnector
   def set_location(user_id, latitude, longitude)
     p 'set_location'
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
-    puts "#{result['id']},#{result['pref']},#{result['area']},#{result['latitude']},#{result['longitude']}"
+    puts "#{result['id']},#{result['pref']},#{result['area']},#{result['latitude']},#{result['longitude']}}"
     return result['pref'], result['area']
   end
 end

--- a/weather_info_connector.rb
+++ b/weather_info_connector.rb
@@ -25,7 +25,7 @@ class WeatherInfoConnector
     when 2
       fix_xpath = xpath + '/info[3]' # 明後日
     else
-      fix_xpath = xpath + '/info[0]' # 今日
+      fix_xpath = xpath + '/info[1]' # 今日
     end
 
     date = doc.elements['fix_xpath'].attributes['date'] # 日時

--- a/weather_info_connector.rb
+++ b/weather_info_connector.rb
@@ -48,7 +48,7 @@ class WeatherInfoConnector
     message << %{#{pref} #{area} の#{date} の天気は #{weather}\n\n}
     message << %{最高気温 #{max}℃\n}
     message << %{最低気温 #{min}℃\n\n}
-    message << %{降水確率 #{text00to06}:#{per00to06}%,#{text06to12}:#{per06to12}%,#{text12to18}:#{per12to18}%,#{text18to24}:#{per18to24}%}
+    message << %{降水確率 #{text00to06}時:#{per00to06}%,#{text06to12}時:#{per06to12}%,#{text12to18}時:#{per12to18}%,#{text18to24}時:#{per18to24}%}
     return message
   end  
 end

--- a/weather_info_connector.rb
+++ b/weather_info_connector.rb
@@ -28,20 +28,20 @@ class WeatherInfoConnector
       fix_xpath = xpath + '/info[1]' # 今日
     end
 
-    date = doc.elements['fix_xpath'].attributes['date'] # 日時
-    weather = doc.elements['fix_xpath' + '/weather'].text  # 天気
-    max = doc.elements['fix_xpath' + '/temperature/range[1]'].text # 最高温
-    min = doc.elements['fix_xpath' + '/temperature/range[2]'].text # 最低気温
+    date = doc.elements[fix_xpath].attributes['date']
+    weather = doc.elements[fix_xpath + '/weather'].text  # 天気
+    max = doc.elements[fix_xpath + '/temperature/range[1]'].text # 最高温
+    min = doc.elements[fix_xpath + '/temperature/range[2]'].text # 最低気温
     # 降水確率
-    per00to06 = doc.elements['fix_xpath' + '/rainfallchance/period[1]'].text  
-    per06to12 = doc.elements['fix_xpath' + '/rainfallchance/period[2]'].text
-    per12to18 = doc.elements['fix_xpath' + '/rainfallchance/period[3]'].text
-    per18to24 = doc.elements['fix_xpath' + '/rainfallchance/period[4]'].text
+    per00to06 = doc.elements[fix_xpath + '/rainfallchance/period[1]'].text  
+    per06to12 = doc.elements[fix_xpath + '/rainfallchance/period[2]'].text
+    per12to18 = doc.elements[fix_xpath + '/rainfallchance/period[3]'].text
+    per18to24 = doc.elements[fix_xpath + '/rainfallchance/period[4]'].text
     # メッセージ送信で使用するためテキストを取得
-    text00to06 = doc.elements['fix_xpath' + "/rainfallchance/period[1]"].attributes['hour'] 
-    text06to12 = doc.elements["fix_xpath" + "/rainfallchance/period[2]"].attributes["hour"]
-    text12to18 = doc.elements["fix_xpath" + "/rainfallchance/period[3]"].attributes["hour"]
-    text18to24 = doc.elements["fix_xpath" + "/rainfallchance/period[4]"].attributes["hour"]
+    text00to06 = doc.elements[fix_xpath + '/rainfallchance/period[1]'].attributes['hour'] 
+    text06to12 = doc.elements[fix_xpath + '/rainfallchance/period[2]'].attributes['hour']
+    text12to18 = doc.elements[fix_xpath + '/rainfallchance/period[3]'].attributes['hour']
+    text18to24 = doc.elements[fix_xpath + '/rainfallchance/period[4]'].attributes['hour']
     
     # Botでメッセージを表示する
     message = ''

--- a/weather_info_connector.rb
+++ b/weather_info_connector.rb
@@ -48,7 +48,7 @@ class WeatherInfoConnector
     message << %{#{pref} #{area} の#{date} の天気は #{weather}\n\n}
     message << %{最高気温 #{max}℃\n}
     message << %{最低気温 #{min}℃\n\n}
-    message << %{降水確率 #{text00to06}時:#{per00to06}%,#{text06to12}時:#{per06to12}%,#{text12to18}時:#{per12to18}%,#{text18to24}時:#{per18to24}%}
+    message << %{降水確率\n#{text00to06}時:#{per00to06}%,#{text06to12}時:#{per06to12}%,\n#{text12to18}時:#{per12to18}%,#{text18to24}時:#{per18to24}%}
     return message
   end  
 end

--- a/weather_info_connector.rb
+++ b/weather_info_connector.rb
@@ -6,7 +6,7 @@ require 'rexml/document'
 # weather = WeatherInfoConnector.new('愛知県', '西部', 'http://www.drk7.jp/weather/xml/23.xml', 'weatherforecast/pref/area[2]', 0)
 
 class WeatherInfoConnector
-  def get_weatherinfo
+  def get_weatherinfo(pref, area, url, xpath, set_day)
     # URIをparse(解析)
     uri = URI.parse(url)
     # ウェブサーバからドキュメントを得る (GET)


### PR DESCRIPTION
## issue番号

close #29 

## 実装内容
- 選択した地域の天気情報を取得
    - 天気情報取得のメソッドに引数を設定していなかったので追加
    - 引用符をつけていたため発生したエラーを解消
- 翌日と2日後の天気情報を取得できるよう実装
- 見にくいメニューの箇所を修正
- XMLファイル内のurlの`http`をsubで`https`に変換

## 参考資料

- [毎朝 天気を通知する LINE Bot を作ってみました。](https://takagusu.hateblo.jp/entry/2017/01/24/200453)
- [【Ruby入門】文字列の置換方法まとめ（gsub sub regex）](https://www.sejuku.net/blog/14685)
- [XML処理　REXMLの使い方](https://aoi-273.hatenadiary.org/entry/20090311/1236764850)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット

- 地域を設定していない場合（名古屋駅の天気）
https://user-images.githubusercontent.com/70443334/131865215-2f3d5166-c389-4186-8601-7c1133095c60.mp4
- 地域を設定した場合（岐阜県の天気）
https://user-images.githubusercontent.com/70443334/131865321-07eca1a9-8dd6-4b98-8b8b-49b02d45903f.mp4



