### PR TITLE
地域をセットするメソッドを修正

### DIFF
--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -72,7 +72,7 @@ class WeatherDbConnector
     p 'set_location'
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result["id"]},#{result["pref"]},#{result["area"]},#{result["latitude"]},#{result["longitude"]}"
-    @conn.execute("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},'#{result["id"]}') on conflict(user_id) do update set area_id = ('#{result["id"]}')")
+    @conn.execute("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},'#{result["id"]}') on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, area_id = excluded.area_id;")
     return result["pref"], result["area"]
   end
 


### PR DESCRIPTION
## issue番号

close #39 

## 実装内容
- 地域を設定するメソッド(`set_location`)を修正

## 参考資料
- [postgreSQLでSELECT/UPSERT](https://qiita.com/sa9ra4ma/items/fca7105b152914793bd6)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認