### PR TITLE
通知時間の設定

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -16,6 +16,11 @@ def client
   }
 end
 
+get '/send' do
+  weather_info_conn = WeatherInfoConnector.new
+  now_time = Time.now
+end
+
 post '/callback' do
   body = request.body.read
   signature = request.env['HTTP_X_LINE_SIGNATURE']

--- a/app.rb
+++ b/app.rb
@@ -19,6 +19,16 @@ end
 get '/send' do
   weather_info_conn = WeatherInfoConnector.new
   now_time = Time.now
+  begin
+    $db.get_all_notifications.each do |row|
+      if rom['notification_disabled'] == false then
+        hour = row['hour'] || 7
+        minute = row['minute'] || 0
+      end
+    end
+  rescue
+  end
+  "OK"
 end
 
 post '/callback' do

--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,7 @@ Bundler.require
 require 'sinatra/reloader' if development?
 require './weather_db_connector'
 require './weather_info_connector'
-require 'date'
+
 
 $db = WeatherDbConnector.new
 

--- a/app.rb
+++ b/app.rb
@@ -54,7 +54,7 @@ post '/callback' do
       reply_text << "  夜の21時に翌日のゴミの収集日をお知らせします。\n\n"
       reply_text << "・「2」または「ストップ」と入力すると、停止します。\n\n"
       reply_text << "・「3」または「天気」と入力すると、現在設定されている地域の天気をお知らせします。\n\n"
-      reply_text << "・通知の時刻を7時から変更したいときは、数字4桁で時刻を入力してください。例:朝8時→0800"
+      reply_text << "・通知の時刻を7時から変更したいときは、半角数字4桁で時刻を入力してください。例:朝8時→0800"
       
       case event.type
       when Line::Bot::Event::MessageType::Text

--- a/app.rb
+++ b/app.rb
@@ -21,9 +21,16 @@ get '/send' do
   now_time = Time.now
   begin
     $db.get_all_notifications.each do |row|
-      if rom['notification_disabled'] == false then
+      if row['notificationDisabled'] == false then
         hour = row['hour'] || 7
         minute = row['minute'] || 0
+        next if hour != (now_time.hour + 9) % 24 # GMTからJISに変換 早期リターン
+        next if minute != now_time.min
+        set_day = hour < 6 ? 1 : 0 # weatherapiは朝6時に更新
+        forecast = weather_info_conn.get_weatherinfo(row['pref'], row['area'], row['url'].sub(/http/, 'https'), row['xpath'], set_day)
+        puts %{#{hour}:#{minute} - #{forecast}}
+        message = { type: 'text', text: forecast }
+        p 'push message'
       end
     end
   rescue
@@ -46,12 +53,17 @@ post '/callback' do
       reply_text << "・「1」または「スタート」と入力すると、毎日朝7時に天気、\n"
       reply_text << "  夜の21時に翌日のゴミの収集日をお知らせします。\n\n"
       reply_text << "・「2」または「ストップ」と入力すると、停止します。\n\n"
-      reply_text << "・「3」または「天気」と入力すると、現在設定されている地域の天気をお知らせします。\n"
+      reply_text << "・「3」または「天気」と入力すると、現在設定されている地域の天気をお知らせします。\n\n"
+      reply_text << "・通知の時刻を7時から変更したいときは、数字4桁で時刻を入力してください。例:朝8時→0800"
       
       case event.type
       when Line::Bot::Event::MessageType::Text
         # 文字列が入力された場合
         case event.message['text']
+        when /([0-2][0-9])([0-5][0-9])/  #正規表現の後方参照を利用
+          hour, minute = $1.to_i, $2.to_i
+          $db.set_time(user_id, hour, minute)
+          reply_text = %{時刻を #{hour}時 #{minute} 分にセットしました！}
         when /.*(1|１|スタート).*/
           $db.notification_enable_user(user_id)
           info = $db.get_notifications(user_id)

--- a/app.rb
+++ b/app.rb
@@ -31,6 +31,7 @@ get '/send' do
         puts %{#{hour}:#{minute} - #{forecast}}
         message = { type: 'text', text: forecast }
         p 'push message'
+        p client.push_message(row['user_id'], message)
       end
     end
   rescue

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -68,6 +68,11 @@ class WeatherDbConnector
     @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notification_disabled = excluded.notification_disabled;")
   end
 
+  def set_time(user_id, hour, minute)
+    p 'set_time'
+    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{hour},#{minute}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, hour = excluded.hour, minute = excluded.minute;")
+  end
+
   def set_location(user_id, latitude, longitude)
     p 'set_location'
     result = @conn.execute("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -70,7 +70,7 @@ class WeatherDbConnector
 
   def set_time(user_id, hour, minute)
     p 'set_time'
-    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notification_disabled) values ('#{user_id}', #{hour},#{minute}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, hour = excluded.hour, minute = excluded.minute;")
+    @conn.execute("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{hour},#{minute}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, hour = excluded.hour, minute = excluded.minute;")
   end
 
   def set_location(user_id, latitude, longitude)


### PR DESCRIPTION
## issue番号

close #33 

## 実装内容
- 通知時間が変更できるよう追加
    - 現在の時刻を取得
    - GMT(グリニッジ標準時)からJIS(日本標準時)の表記になるよう計算
    - 1日の切り替えがAPIが更新される朝の6時になるよう条件式を設定
    - 正規表現の後方参照を利用して半角数字4桁で時間・分が設定できるよう実装

## 参考資料
- [毎朝 天気を通知する LINE Bot を作ってみました。](https://takagusu.hateblo.jp/entry/2017/01/24/200453)
- [Rubyによる現在日時取得(now)の方法について現役エンジニアが解説【初心者向け】](https://techacademy.jp/magazine/49468)
- [制御構造](https://docs.ruby-lang.org/ja/latest/doc/spec=2fcontrol.html)
- [Rubyのイテレータ](https://dev-yakuza.posstree.com/ruby/iterator/)
- [Ruby + SinatraでLINE Botを作ろう – Part 3](https://www.mizucoffee.com/archives/1126)
- [Rubyで使われる記号の意味（正規表現の複雑な記号は除く）](https://docs.ruby-lang.org/ja/latest/doc/symref.html)
- [現場で役立つ！Rubyで演算子を使う方法【初心者向け】](https://techacademy.jp/magazine/6771)
- [除算による商と剰余を取得する](https://www.javadrive.jp/ruby/numeric_class/index6.html)
- [GMT グリニッジ標準時の時差](https://www.jisakeisan.com/timezone/gmt/)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット

https://user-images.githubusercontent.com/70443334/132117841-e6b84854-bfa1-4834-8b1f-0646d45f76dd.mp4