### PR TITLE
Herokuの環境変数を導入

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec ruby web.rb -p $PORT
+web: bundle exec ruby app.rb -p $PORT

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec ruby app.rb
+web: bundle exec ruby web.rb -p $PORT

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -7,22 +7,30 @@ class WeatherDbConnector
   DEFAULT_WEATHER_MINUTE = 0
   DEFAULT_AREA_ID = 1
 
-  def initialize
-   connect
-   init
-  end
-
   # 環境変数を使って接続する
   def connect
-    @@client = PG::Connection.new(
-      :host => "",
+    connection = PG::connect(
+      :host => "localhost",
       :user => ENV["DB_USER"],
       :password => ENV["DB_PASSWORD"],
       :dbname => ENV["DB_NAME"]
     )
+
+    begin
+      initialize
+      notification_enable_user(user_id)
+      notification_disnable_user(user_id)
+      set_time(user_id, hour, minute)
+      set_location(user_id, latitude, longitude)
+      get_all_notifications
+      get_notifications(user_id)
+      fix_notifications
+    ensure
+      connection.finish
+    end
   end
   
-  def init
+  def initialize
     # 毎回リセットする
     drop_weathers
     create_weathers
@@ -33,13 +41,13 @@ class WeatherDbConnector
     p 'create_weathers_table'
     File.open('create_weathers.sql', 'r:utf-8') do |f|
       createsql = f.read
-      @@client.exec(createsql)
+      connection.exec(createsql)
     end
 
     p 'create_notifications_table'
     File.open('notification.sql', 'r:utf-8') do |f|
       notificationsql = f.read
-      @@client.exec(notificationsql)
+      connection.exec(notificationsql)
     end
   end
 
@@ -47,43 +55,43 @@ class WeatherDbConnector
     p 'insert_weathers_table'
     File.open('insert_weathers.sql', 'r:utf-8') do |f|
       f.each_line do |createsql|
-        @@client.exec(createsql)
+        connection.exec(createsql)
       end
     end
   end
 
   def drop_weathers
     p 'drop_weathers_table'
-    @@client.exec("drop table if exists weathers")
-    @@client.exec("drop table if exists notifications")
+    connection.exec("drop table if exists weathers")
+    connection.exec("drop table if exists notifications")
   end
 
   def notification_enable_user(user_id)
     p 'enable_user'
-    @@client.exec("insert into notifications (user_id, hour, minute, area_id, notificationDisabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, false) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notificationDisabled = excluded.notificationDisabled;")
+    connection.exec("insert into notifications (user_id, hour, minute, area_id, notificationDisabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, false) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notificationDisabled = excluded.notificationDisabled;")
   end
 
   def notification_disnable_user(user_id)
     p 'disnable_user'
-    @@client.exec("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notificationDisabled = excluded.notificationDisabled;")
+    connection.exec("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notificationDisabled = excluded.notificationDisabled;")
   end
 
   def set_time(user_id, hour, minute)
     p 'set_time'
-    @@client.exec("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{hour},#{minute}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, hour = excluded.hour, minute = excluded.minute;")
+    connection.exec("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{hour},#{minute}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, hour = excluded.hour, minute = excluded.minute;")
   end
 
   def set_location(user_id, latitude, longitude)
     p 'set_location'
-    result = @@client.exec("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
+    result = connection.exec("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result["id"]},#{result["pref"]},#{result["area"]},#{result["latitude"]},#{result["longitude"]}"
-    @@client.exec("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},'#{result["id"]}') on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, area_id = excluded.area_id;")
+    connection.exec("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},'#{result["id"]}') on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, area_id = excluded.area_id;")
     return result["pref"], result["area"]
   end
 
   def get_all_notifications
    p 'get_all_notifications'
-   results = @@client.exec('select * from notifications inner join weathers on notifications.area_id = weathers.id;')
+   results = connection.exec('select * from notifications inner join weathers on notifications.area_id = weathers.id;')
    results.each do |row|
     puts "----------------------------"
     p row
@@ -93,7 +101,7 @@ class WeatherDbConnector
 
   def get_notifications(user_id)
     p 'get_notifications(user_id)'
-    results = @@client.exec("select * from notifications inner join weathers on notifications.area_id = weathers.id where notifications.user_id = '#{user_id}';")
+    results = connection.exec("select * from notifications inner join weathers on notifications.area_id = weathers.id where notifications.user_id = '#{user_id}';")
     results.each do |row|
       puts "----------------------------"
       p row
@@ -103,6 +111,6 @@ class WeatherDbConnector
 
   def fix_notifications
     p 'fix_notifications'
-    @@client.exec("update notifications set hour = 7, minute = 0 where hour is null")
+    connection.exec("update notifications set hour = 7, minute = 0 where hour is null")
   end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -7,30 +7,15 @@ class WeatherDbConnector
   DEFAULT_WEATHER_MINUTE = 0
   DEFAULT_AREA_ID = 1
 
-  # 環境変数を使って接続する
-  def connect
-    connection = PG::connect(
+  
+  def initialize
+    # 環境変数を使って接続する
+    @conn = PG.connect(
       :host => "localhost",
       :user => ENV["DB_USER"],
       :password => ENV["DB_PASSWORD"],
       :dbname => ENV["DB_NAME"]
     )
-
-    begin
-      initialize
-      notification_enable_user(user_id)
-      notification_disnable_user(user_id)
-      set_time(user_id, hour, minute)
-      set_location(user_id, latitude, longitude)
-      get_all_notifications
-      get_notifications(user_id)
-      fix_notifications
-    ensure
-      connection.finish
-    end
-  end
-  
-  def initialize
     # 毎回リセットする
     drop_weathers
     create_weathers
@@ -41,13 +26,13 @@ class WeatherDbConnector
     p 'create_weathers_table'
     File.open('create_weathers.sql', 'r:utf-8') do |f|
       createsql = f.read
-      connection.exec(createsql)
+      @conn.exec(createsql)
     end
 
     p 'create_notifications_table'
     File.open('notification.sql', 'r:utf-8') do |f|
       notificationsql = f.read
-      connection.exec(notificationsql)
+      @conn.exec(notificationsql)
     end
   end
 
@@ -55,43 +40,43 @@ class WeatherDbConnector
     p 'insert_weathers_table'
     File.open('insert_weathers.sql', 'r:utf-8') do |f|
       f.each_line do |createsql|
-        connection.exec(createsql)
+        @conn.exec(createsql)
       end
     end
   end
 
   def drop_weathers
     p 'drop_weathers_table'
-    connection.exec("drop table if exists weathers")
-    connection.exec("drop table if exists notifications")
+    @conn.exec("drop table if exists weathers")
+    @conn.exec("drop table if exists notifications")
   end
 
   def notification_enable_user(user_id)
     p 'enable_user'
-    connection.exec("insert into notifications (user_id, hour, minute, area_id, notificationDisabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, false) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notificationDisabled = excluded.notificationDisabled;")
+    @conn.exec("insert into notifications (user_id, hour, minute, area_id, notificationDisabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, false) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notificationDisabled = excluded.notificationDisabled;")
   end
 
   def notification_disnable_user(user_id)
     p 'disnable_user'
-    connection.exec("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notificationDisabled = excluded.notificationDisabled;")
+    @conn.exec("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, notificationDisabled = excluded.notificationDisabled;")
   end
 
   def set_time(user_id, hour, minute)
     p 'set_time'
-    connection.exec("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{hour},#{minute}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, hour = excluded.hour, minute = excluded.minute;")
+    @conn.exec("insert into notifications (user_id, hour,minute, area_id, notificationDisabled) values ('#{user_id}', #{hour},#{minute}, #{DEFAULT_AREA_ID}, true) on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, hour = excluded.hour, minute = excluded.minute;")
   end
 
   def set_location(user_id, latitude, longitude)
     p 'set_location'
-    result = connection.exec("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
+    result = @conn.exec("select * from weathers order by abs(latitude - #{latitude}) + abs(longitude - #{longitude}) asc;").first
     puts "#{result["id"]},#{result["pref"]},#{result["area"]},#{result["latitude"]},#{result["longitude"]}"
-    connection.exec("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},'#{result["id"]}') on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, area_id = excluded.area_id;")
+    @conn.exec("insert into notifications (user_id, hour, minute, area_id) values ('#{user_id}', #{DEFAULT_WEATHER_HOUR},#{DEFAULT_WEATHER_MINUTE},'#{result["id"]}') on conflict on constraint notifications_pkey do update set user_id = excluded.user_id, area_id = excluded.area_id;")
     return result["pref"], result["area"]
   end
 
   def get_all_notifications
    p 'get_all_notifications'
-   results = connection.exec('select * from notifications inner join weathers on notifications.area_id = weathers.id;')
+   results = @conn.exec('select * from notifications inner join weathers on notifications.area_id = weathers.id;')
    results.each do |row|
     puts "----------------------------"
     p row
@@ -101,7 +86,7 @@ class WeatherDbConnector
 
   def get_notifications(user_id)
     p 'get_notifications(user_id)'
-    results = connection.exec("select * from notifications inner join weathers on notifications.area_id = weathers.id where notifications.user_id = '#{user_id}';")
+    results = @conn.exec("select * from notifications inner join weathers on notifications.area_id = weathers.id where notifications.user_id = '#{user_id}';")
     results.each do |row|
       puts "----------------------------"
       p row
@@ -111,6 +96,6 @@ class WeatherDbConnector
 
   def fix_notifications
     p 'fix_notifications'
-    connection.exec("update notifications set hour = 7, minute = 0 where hour is null")
+    @conn.exec("update notifications set hour = 7, minute = 0 where hour is null")
   end
 end

--- a/weather_db_connector.rb
+++ b/weather_db_connector.rb
@@ -9,12 +9,13 @@ class WeatherDbConnector
 
   
   def initialize
-    # 環境変数を使って接続する
-    @conn = PG.connect(
-      :host => "localhost",
-      :user => ENV["DB_USER"],
-      :password => ENV["DB_PASSWORD"],
-      :dbname => ENV["DB_NAME"]
+    uri = URI.parse(ENV['DATABASE_URL'])
+    @conn ||= PG::connect(
+      host: uri.hostname,
+      dbname: uri.path[1..-1],
+      user: uri.user,
+      port: uri.port,
+      password: uri.password
     )
     # 毎回リセットする
     drop_weathers


### PR DESCRIPTION
## issue番号

close #60 

## 実装内容

- `6a584a5`はコミットメッセージの重複（実装は以前行ったもの）
- 接続の記述を検討→parseを使用した書き方に変更

## 参考資料
- [SinatraアプリをHerokuへデプロイする手順](https://qiita.com/HEP/items/74002f0ab95d82713be0)
- [Herokuでステージング環境を作る](https://blog.ruedap.com/2011/02/20/ruby-heroku-staging-enviroment)
- [`pg`を使ったRubyからDBのデータを呼び出す手順](https://ksmxxxxxx.hatenablog.com/entry/2020/12/29/234906)
- [HerokuのDBにローカルPCからアクセスしたいんだけど...](https://qiita.com/akiko-pusu/items/305e291465d6aac04bf3)
- [PostgreSQLにデータを挿入する](https://rowingfan.hatenablog.jp/entry/2018/04/19/143000#%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%92%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%82%80)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

