### PR TITLE
HerokuSchedulerの設定

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -20,37 +20,6 @@ def client
   }
 end
 
-get '/send' do
-  weather_info_conn = WeatherInfoConnector.new
-  now_time = Time.now
-  begin
-    $db.get_all_notifications.each do |row|
-      if row['notificationDisabled'] == false then
-        hour = row['hour'] || 7
-        minute = row['minute'] || 0
-        next if hour != (now_time.hour + 9) % 24 # GMTからJISに変換 早期リターン
-        next if minute != now_time.min
-        set_day = hour < 6 ? 1 : 0 # weatherapiは朝6時に更新
-        forecast = weather_info_conn.get_weatherinfo(row['pref'], row['area'], row['url'].sub(/http/, 'https'), row['xpath'], set_day)
-        puts %{#{hour}:#{minute} - #{forecast}}
-        message = { type: 'text', text: forecast }
-        p 'push message'
-
-        case forecast
-        when /.*(雨|雪).*/ 
-          message_sticker = {"type": "sticker", "packageId": "446", "stickerId": "1994"}
-          messages = [message, message_sticker]
-          p client.push_message(row['user_id'], messages)
-        else
-          p client.push_message(row['user_id'], message)
-        end
-      end
-    end
-  rescue
-  end
-  "OK"
-end
-
 post '/callback' do
   body = request.body.read
   signature = request.env['HTTP_X_LINE_SIGNATURE']

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,2 @@
-require './app.rb'
+require './app'
 run Sinatra::Application

--- a/weather_task.rb
+++ b/weather_task.rb
@@ -1,0 +1,34 @@
+require './app'
+
+# Heroku Schedulerで実行する処理
+get '/send' do
+  weather_info_conn = WeatherInfoConnector.new
+  now_time = Time.now
+  begin
+    $db.get_all_notifications.each do |row|
+      if row['notificationDisabled'] == false then
+        hour = row['hour'] || 7
+        minute = row['minute'] || 0
+        next if hour != (now_time.hour + 9) % 24 # GMTからJISに変換 早期リターン
+        next if minute != now_time.min
+        set_day = hour < 6 ? 1 : 0 # weatherapiは朝6時に更新
+        forecast = weather_info_conn.get_weatherinfo(row['pref'], row['area'], row['url'].sub(/http/, 'https'), row['xpath'], set_day)
+        puts %{#{hour}:#{minute} - #{forecast}}
+        message = { type: 'text', text: forecast }
+        p 'push message'
+
+        case forecast
+        when /.*(雨|雪).*/ 
+          message_sticker = {"type": "sticker", "packageId": "446", "stickerId": "1994"}
+          messages = [message, message_sticker]
+          p client.push_message(row['user_id'], messages)
+        else
+          p client.push_message(row['user_id'], message)
+        end
+      end
+    end
+  rescue
+  end
+  "OK"
+end
+puts 'done.'


### PR DESCRIPTION
## issue番号

close #36 

## 実装内容
- HerokuSchedulerの設定
    - `weather_task.rb`を作成して定期実行したい箇所を移動させる
    - 拡張子を削除(requireの書き方を統一するため)
 
## 参考資料
参考資料を記載してください
- [heroku schedulerの使い方(Rails,sinatra)](https://qiita.com/kyohei8/items/5a7d7db3838728a04140)
- [Pythonのプログラムの定期実行が無料でできるHerokuのscheduler](https://hashikake.com/heroku-scheculer)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット
<img width="500" alt="herokuscheduler登録" src="https://user-images.githubusercontent.com/70443334/133628897-184d2b3b-73d7-4b9f-a88f-c2ebc51f012d.png">
