### PR TITLE
herokuにデプロイしたアプリとclockworkの紐付け

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec ruby app.rb -p $PORT
+cron: bundle exec clockwork clock.rb


### PR DESCRIPTION
## issue番号

close #83 

## 実装内容
herokuにデプロイしたアプリとclockworkの紐付け
- Procfileをcronに変更

## 参考資料
- [Heroku で定期実行アプリケーションを動かそう！](http://www.ownway.info/Ruby/heroku/helloclockwork)
- [clockwork について](http://www.ownway.info/Ruby/clockwork/about)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

